### PR TITLE
chore: switch to universal dev image

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,7 +6,7 @@ attributes:
 components:
   - name: python
     container:
-      image: quay.io/devfile/base-developer-image:ubi8-7bd4fe3
+      image: quay.io/devfile/universal-developer-image:ubi8-3735d4f
       volumeMounts:
         - name: venv
           path: /home/user/.venv


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Use universal developer image with installed pylint.

Fixed https://github.com/eclipse/che/issues/20645