### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,23 +2,25 @@ schemaVersion: 2.1.0
 metadata:
   name: python-hello-world
 components:
-  - name: python
+  - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-3735d4f
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       volumeMounts:
         - name: venv
           path: /home/user/.venv
       memoryLimit: 512Mi
       mountSources: true
+
   - name: venv
     volume:
       size: 1G
+
 commands:
-  - id: run
+  - id: run-application
     exec:
-      label: "Run the application"
-      component: python
-      workingDir: ${PROJECTS_ROOT}/python-hello-world
+      label: "Run application"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
       commandLine: "python3 hello-world.py"
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
