### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: python-hello-world
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-16_31_15](https://github.com/che-samples/python-hello-world/assets/1271546/7742107f-c5e9-436f-bfbc-6a3ba4900447)

Related issue: https://github.com/eclipse/che/issues/21985

